### PR TITLE
Add line to Podspec for tvOS support

### DIFF
--- a/Fleet.podspec
+++ b/Fleet.podspec
@@ -6,6 +6,7 @@ Pod::Spec.new do |s|
   s.license                 = { :type => "Apache 2.0", :file => "LICENSE" }
   s.author                  = "Jared Friese"
   s.ios.deployment_target   = "8.0"
+  s.tvos.deployment_target  = "10.0"
   s.source                  = { :git => "https://github.com/jwfriese/Fleet.git", :tag => "#{s.version}" }
   s.source_files            = "Fleet/**/*.{swift,h,m}"
   s.public_header_files     = ["Fleet/Fleet.h", "Fleet/ObjC/FleetObjC.h"]


### PR DESCRIPTION
Without this when trying to pod install into a tvOS app you get the following error:

> The platform of the target `CableClixTests` (tvOS 10.0) is not compatible with `Fleet (3.3.0)`, which does not support `tvos`.