### PR TITLE
Disable dismiss animation in tapAlertAction()

### DIFF
--- a/Fleet/CoreExtensions/Alerts/UIAlertController+Fleet.swift
+++ b/Fleet/CoreExtensions/Alerts/UIAlertController+Fleet.swift
@@ -42,7 +42,7 @@ extension UIAlertController {
                 }
             }
 
-            presentingViewController?.dismiss(animated: true, completion: completionHandler)
+            presentingViewController?.dismiss(animated: false, completion: completionHandler)
         } else {
             FleetError(Fleet.AlertError.titleNotFound(title: title)).raise()
         }


### PR DESCRIPTION
Hopefully it can positively impact duration of tests that exercise interaction with `UIAlertController` class.