### PR TITLE
Replace initialize with load in CoreExtensions

### DIFF
--- a/Fleet/CoreExtensions/Alerts/UIAlertAction+Fleet.m
+++ b/Fleet/CoreExtensions/Alerts/UIAlertAction+Fleet.m
@@ -5,7 +5,7 @@ BOOL didSwizzleUIAlertAction = NO;
 
 @implementation UIAlertAction (FleetPrivate)
 
-+ (void)initialize {
++ (void)load {
     if (self == [UIAlertAction class]) {
         if (!didSwizzleUIAlertAction) {
             [self objc_swizzleHandlerSetter];

--- a/Fleet/CoreExtensions/Storyboard/UIStoryboard+Fleet.m
+++ b/Fleet/CoreExtensions/Storyboard/UIStoryboard+Fleet.m
@@ -5,7 +5,7 @@ BOOL didSwizzleUIStoryboard = NO;
 
 @implementation UIStoryboard (FleetPrivate)
 
-+ (void)initialize {
++ (void)load {
     if (self == [UIStoryboard class]) {
         if (!didSwizzleUIStoryboard) {
             [self objc_swizzleViewControllerInstantiationMethod];

--- a/Fleet/CoreExtensions/TableView/UITableViewRowAction+Fleet.m
+++ b/Fleet/CoreExtensions/TableView/UITableViewRowAction+Fleet.m
@@ -5,7 +5,7 @@ BOOL didSwizzleUITableViewRowAction = NO;
 
 @implementation UITableViewRowAction (FleetPrivate)
 
-+ (void)initialize {
++ (void)load {
     if (self == [UITableViewRowAction class]) {
         if (!didSwizzleUITableViewRowAction) {
             [self objc_swizzleInit];

--- a/Fleet/CoreExtensions/UINavigationController+Fleet.m
+++ b/Fleet/CoreExtensions/UINavigationController+Fleet.m
@@ -5,7 +5,7 @@ BOOL didSwizzleUINavigationController = NO;
 
 @implementation UINavigationController (FleetPrivate)
 
-+ (void)initialize {
++ (void)load {
     if (self == [UINavigationController class]) {
         if (!didSwizzleUINavigationController) {
             [self objc_swizzlePushViewController];

--- a/Fleet/CoreExtensions/ViewController/UIViewController+Fleet.m
+++ b/Fleet/CoreExtensions/ViewController/UIViewController+Fleet.m
@@ -5,7 +5,7 @@ BOOL didSwizzleUIViewController = NO;
 
 @implementation UIViewController (FleetPrivate)
 
-+ (void)initialize {
++ (void)load {
     if (self == [UIViewController class]) {
         if (!didSwizzleUIViewController) {
             [self objc_swizzleViewDidLoad];


### PR DESCRIPTION
When using `Fleet` in Xcode 14 you would get an error:

```
Application circumvented Objective-C runtime dealloc initiation for (...)
```

Similar issues are mentioned in:
https://github.com/hackiftekhar/IQKeyboardManager/issues/1905
https://developer.apple.com/forums/thread/711358
https://stackoverflow.com/q/74155243

According to [this SO answer](https://stackoverflow.com/a/74687194), the solution is to replace the `initialize` methods with `load`.

